### PR TITLE
python 3.10 compatible MutableSet

### DIFF
--- a/pybullet_tools/utils.py
+++ b/pybullet_tools/utils.py
@@ -19,6 +19,10 @@ import shutil
 import cProfile
 import pstats
 
+if sys.version_info >= (3, 10):
+    from collections.abc import MutableSet
+else:
+    from collections import MutableSet
 from collections import defaultdict, deque, namedtuple
 from itertools import product, combinations, count, cycle, islice
 from multiprocessing import TimeoutError
@@ -345,7 +349,7 @@ def named_tuple(name, fields, defaults=None):
         NT.__new__.__defaults__ = defaults
     return NT
 
-class OrderedSet(collections.OrderedDict, collections.MutableSet):
+class OrderedSet(collections.OrderedDict, MutableSet):
     # TODO: https://stackoverflow.com/questions/1653970/does-python-have-an-ordered-set
     def __init__(self, seq=()): # known special case of set.__init__
         #super(OrderedSet, self).__init__()


### PR DESCRIPTION
Making PR2 TAMP example work in python 3.10 as mentioned in https://github.com/caelan/pddlstream/pull/35#issuecomment-1154658107
Require commit `f067901bfabd3cd1a21ae42ef2088733eb1da476` in PR https://github.com/caelan/pddlstream/pull/35  to work