### PR TITLE
Fix decompose paths bug

### DIFF
--- a/pybullet_tools/retime.py
+++ b/pybullet_tools/retime.py
@@ -24,7 +24,7 @@ def decompose_into_paths(joints, path):
     for q1, q2 in get_pairs(path):
         # Zero velocities aren't enforced otherwise
         indices, = np.nonzero(get_difference(q1, q2))
-        # if 2 consecutive states exist (no nonzero elements exist) skiip.
+        # if 2 consecutive states exist that are duplicate (no nonzero elements exist) skip.
         if not len(indices):
             continue
         current_joints = tuple(joints[j] for j in indices)

--- a/pybullet_tools/retime.py
+++ b/pybullet_tools/retime.py
@@ -24,6 +24,9 @@ def decompose_into_paths(joints, path):
     for q1, q2 in get_pairs(path):
         # Zero velocities aren't enforced otherwise
         indices, = np.nonzero(get_difference(q1, q2))
+        # if 2 consecutive states exist (no nonzero elements exist) skiip.
+        if not len(indices):
+            continue
         current_joints = tuple(joints[j] for j in indices)
         if not joint_sequence or (current_joints != joint_sequence[-1]):
             if current_path:


### PR DESCRIPTION
If a trajectory with 2 consecutive duplicate states exists, then the current implementation of decompose_into_paths will consider this a new joint_group with 0 joints since none of the joints is manipulated. The proposed fix simply removes the duplicate consecutive state.
